### PR TITLE
Center image in pentest-agent-system documentation

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,3 +2,11 @@
 ---
 
 @import "{{ site.theme }}";
+
+.centered {
+    text-align: center; /* Center the image horizontally */
+  }
+  
+  .centered img {
+    display: inline-block; /* Ensures the image is treated as a block-level element for better alignment */
+  }

--- a/pentest-agent-system.md
+++ b/pentest-agent-system.md
@@ -7,7 +7,9 @@ width: 100%
 
 # Pentest Agent System: An Autonomous Multi-Agent Framework for Penetration Testing Based on the MITRE ATT&CK Framework
 
-![pentest-agent-system](https://raw.githubusercontent.com/youngsecurity/www/refs/heads/main/assets/images/DALL%C2%B7E%202025-03-22%2017.47.42.png)
+<div style="text-align: center;">
+    <img src="{{ 'https://raw.githubusercontent.com/youngsecurity/www/refs/heads/main/assets/images/DALL%C2%B7E%202025-03-22%2017.47.42.png' | relative_url }}" alt="pentest-agent-system">
+</div>
 
 ## Abstract
 


### PR DESCRIPTION
Improve the presentation of the pentest-agent-system documentation by centering the main image.