### PR TITLE
Remove outdated planned enhancements from documentation

### DIFF
--- a/pentest-agent-system.md
+++ b/pentest-agent-system.md
@@ -2532,5 +2532,3 @@ Planned enhancements for future versions include:
 6. **Network-based Flag Submission**: Implementing automatic submission of flags to validation systems for CTF-style challenges.
     
 7. **Improved LLM Integration**: Exploring fine-tuning of models specifically for security tasks to improve performance and reduce hallucinations.
-
----


### PR DESCRIPTION
Eliminate references to outdated planned enhancements in the pentest-agent-system documentation to ensure clarity and relevance.